### PR TITLE
Fixes and Usage Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 simple-chroot is a bash script that manages installation and uninstallation of executable files on chrooted environments. The script automatically identifies the dependencies of the executables you want to install or purge using `ldd`. If you install an executable, its dependencies are cloned automatically. You can uninstall these executables later on, and dependencies that are no longer needed by any other executables are deleted automatically. The chroot environment is assumed to be the working directory of the script.
 
-##Installing files
+
+## Executing files
+
+```
+# create a folder for the jail and enter it
+mkdir jail && cd jail
+
+# execute bash directly
+$ ./simple-chroot.sh execute bash
+```
+
+## Installing files
 
 ```
 # create a folder for the jail and enter it
@@ -18,9 +29,11 @@ $ ./simple-chroot.sh install bash vim /path/to/another/executable
 $ ./simple-chroot.sh purge vim /path/to/another/executable
 ```
 
-##Referencing files
+## Referencing files
+
 You can reference a file using one of the following ways...
 
 1. the absolute path to the file
 2. a relative path (that starts with a dot) to the file
 3. if the file is recognized as an external command, like `ls`, you can use the command name directly, and it will be expanded using `type`, a bash builtin.
+

--- a/simple-chroot.sh
+++ b/simple-chroot.sh
@@ -6,6 +6,7 @@
 
 function usage {
 	echo "Usage: ./simple-chroot.sh    help"
+	echo "                             execute {file_path | external_command}"
 	echo "                             install {file_path | external_command}..."
 	echo "                             purge   {file_path | external_command}..."
 }
@@ -114,6 +115,15 @@ function collect_deps {
 	echo "$deps"
 }
 
+function jail_execute {
+	local path_to_file="$1"
+
+	jail_install "$1"
+	sudo chroot ./ "$1"
+
+	return $?
+}
+
 function jail_install {
 	local path_to_file="$1"
 
@@ -185,7 +195,7 @@ FILE_INSTALLED=".jail-data/installed"
 
 for arg; do
 	if [[ $action == "" ]]; then
-		if [[ "$arg" == install ]] || [[ "$arg" == purge ]] ; then
+		if [[ "$arg" == execute ]] || [[ "$arg" == install ]] || [[ "$arg" == purge ]] ; then
 			if (( "$#" < 2 )); then
 				echo_fatal "too few arguments!"
 				usage

--- a/simple-chroot.sh
+++ b/simple-chroot.sh
@@ -5,9 +5,9 @@
 # found in the LICENSE file.
 
 function usage {
-	echo "Usage: ./simple-chroot.sh    help |"
-	echo "                             install {file_path | external_command}... |"
-	echo "                             purge {file_path | external_command}..."
+	echo "Usage: ./simple-chroot.sh    help"
+	echo "                             install {file_path | external_command}..."
+	echo "                             purge   {file_path | external_command}..."
 }
 
 function echo_fatal {
@@ -155,14 +155,14 @@ function check_command {
 	command_type="$(type -t "$1")"
 
 	if [[ "$command_type" == builtin ]] ; then
-		echo_fatal "\`$1' is a builtin!";
+		echo_fatal "\`$1' is a builtin!"
 		echo_note "try installing a shell instead, e.g. bash!"
-		exit 1;
+		exit 1
 	fi
 
 	if [[ "$command_type" != "file" ]] ; then
-		echo_fatal "\`$1' command not found!";
-		exit 1;
+		echo_fatal "\`$1' command not found!"
+		exit 1
 	fi
 
 	command_file="$(type -P "$1")"
@@ -173,7 +173,7 @@ function check_command {
 function check_file {
 	if [[ ! -f "$1" ]]; then
 		echo_fatal "\`$1' is not a file!"
-		exit 1;
+		exit 1
 	fi
 }
 
@@ -192,7 +192,7 @@ for arg; do
 				exit 1
 			fi
 			action="jail_$arg"
-		elif [[ "$arg" == help ]]; then
+		elif [[ "$arg" == help ]] || [[ "$arg" == "--help" ]]; then
 			usage
 			exit 0
 		else
@@ -201,10 +201,10 @@ for arg; do
 			exit 1
 		fi
 	else
-		if [[ "$arg" == /* ]] ; then
+		if [[ "$arg" == /* ]]; then
 			check_file "$arg"
 			paths_to_files+=("$arg")
-		elif [[ "$arg" == .* ]] ; then
+		elif [[ "$arg" == .* ]]; then
 			check_file "$arg"
 			paths_to_files+=("$(realpath $arg)")
 		else


### PR DESCRIPTION
Hey @mh5 

I just found the `simple-chroot` tool and I created a package for `AUR` (for Arch Linux) which is available here: https://aur.archlinux.org/packages/simple-chroot-git

In order to have a better integration with distro I fixed some minor things. This pull request will do:

- Fix usage for `--help` typing fellows
- Remove unnecessary semicolons (assuming this is the statistical codestyle)
- Add a `jail_execute` method that just reuses `jail_install` and executes the binary directly using the `chroot` command and `sudo`.
- README cleanup for GitHub

Please let me know if you agree with those changes or whether those are okay.

Thank you for your tool, it already improved my life <3
~Chris (aka @cookiengineer)
